### PR TITLE
feat: add storacha-get command to download files from Storacha

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,20 @@ Delete files or folders from S3
 - Use `-prefix` with `-recursive` for folders
 - The `-force` flag skips confirmation prompts
 - Prefix deletion uses batch operations (1000 objects per API call)
+
+### Download from Storacha
+```bash
+# Download a file from a directory CID (most common — storacha wraps uploads in a dir)
+./bin/rclone storacha-get -cid  -file  -out 
+
+# Example
+./bin/rclone storacha-get \
+  -cid bafybeihjnbauyqkqq4xibszzm3jpjf4vhlgb2yddabqodnrmcbvdnihyau \
+  -file lol2.txt \
+  -out downloaded.txt
+```
+
+**Notes:**
+- `-cid` is the CID printed by `storacha-put` (required)
+- `-file` is the original filename inside the uploaded directory (required for directory CIDs)
+- `-out` is the local path to save to (defaults to the value of `-file`)

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -259,6 +259,40 @@ func StorachaPut(args []string) {
 	fmt.Printf("View at: https://w3s.link/ipfs/%s\n", cid)
 }
 
+func StorachaGet(args []string) {
+	fs := flag.NewFlagSet("storacha-get", flag.ExitOnError)
+	cid := fs.String("cid", "", "CID to download (required)")
+	file := fs.String("file", "", "filename inside the CID directory (e.g. lol.txt)")
+	outPath := fs.String("out", "", "local output path (defaults to filename)")
+	if err := fs.Parse(args); err != nil {
+		log.Fatal(err)
+	}
+
+	if *cid == "" {
+		fmt.Println("Error: -cid is required")
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	cfg, err := config.LoadStoracha()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	client, err := storacha.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("create storacha client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	fmt.Printf("Downloading from Storacha...\n")
+
+	if err := client.DownloadFile(ctx, *cid, *file, *outPath); err != nil {
+		log.Fatalf("download failed: %v", err)
+	}
+}
+
 func Copy(args []string) {
 	fs := flag.NewFlagSet("cp", flag.ExitOnError)
 	s3Key := fs.String("s3-key", "", "S3 object key to copy (required)")

--- a/internal/storacha/storacha.go
+++ b/internal/storacha/storacha.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"net/http"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -194,6 +195,65 @@ func (c *Client) UploadFromS3(ctx context.Context, awsCfg config.AppConfig, s3Ke
 	}
 
 	return cid, nil
+}
+
+func (c *Client) DownloadFile(ctx context.Context, cid string, fileName string, destPath string) error {
+	if destPath == "" {
+		if fileName != "" {
+			destPath = fileName
+		} else {
+			destPath = cid
+		}
+	}
+
+	var url string
+	if fileName != "" {
+		// directory CID — subdomain style with filename path
+		url = fmt.Sprintf("https://%s.ipfs.w3s.link/%s", cid, fileName)
+	} else {
+		// raw file CID
+		url = fmt.Sprintf("https://%s.ipfs.w3s.link", cid)
+	}
+
+	fmt.Printf("Fetching from: %s\n", url)
+
+	client := &http.Client{
+		Timeout: 5 * time.Minute,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http get: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("gateway returned status: %s", resp.Status)
+	}
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("create file %s: %w", destPath, err)
+	}
+	defer func() {
+		closeErr := f.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
+
+	n, err := io.Copy(f, resp.Body)
+	if err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	fmt.Printf("✓ Downloaded %d bytes → %s\n", n, destPath)
+	return nil
 }
 
 func (c *Client) Close() error {

--- a/main.go
+++ b/main.go
@@ -10,14 +10,15 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println(`usage:
-  storacha-rclone aws-login                 # save AWS keys/region/bucket
-  storacha-rclone s3-ls [-prefix p/]        # list S3 objects
-  storacha-rclone s3-get -key k [-out f]    # download from S3
-  storacha-rclone s3-rm -key k              # delete from S3
+  storacha-rclone aws-login                 		# save AWS keys/region/bucket
+  storacha-rclone s3-ls [-prefix p/]        		# list S3 objects
+  storacha-rclone s3-get -key k [-out f]    		# download from S3
+  storacha-rclone s3-rm -key k              		# delete from S3
 
-  storacha-rclone storacha-login            # save Storacha credentials
-  storacha-rclone storacha-put -file f      # upload file to Storacha
-  storacha-rclone cp -s3-key k              # copy S3 object to Storacha`)
+  storacha-rclone storacha-login            		# save Storacha credentials
+  storacha-rclone storacha-put -file f      		# upload file to Storacha
+  storacha-rclone storacha-get -cid <cid> [-out f] 	# download from Storacha
+  storacha-rclone cp -s3-key k              		# copy S3 object to Storacha`)
 		os.Exit(2)
 	}
 
@@ -36,6 +37,8 @@ func main() {
 		commands.StorachaPut(os.Args[2:])
 	case "cp":
 		commands.Copy(os.Args[2:])
+	case "storacha-get":
+		commands.StorachaGet(os.Args[2:])
 	default:
 		fmt.Println("unknown command:", os.Args[1])
 		os.Exit(2)


### PR DESCRIPTION
## Summary
Adds a new `storacha-get` command that allows downloading files from Storacha using the `w3s.link` IPFS gateway. This completes the basic read/write cycle for Storacha — you can now upload with `storacha-put` and download back with `storacha-get`.

---

## Changes

### `internal/storacha/storacha.go`
- Added `DownloadFile(ctx, cid, fileName, destPath string)` method on `Client`
- Uses `https://<cid>.ipfs.w3s.link/<filename>` for directory CIDs
- Uses `https://<cid>.ipfs.w3s.link` for raw file CIDs
- Streams response body directly to disk with proper error handling and deferred close cleanup
- 5 minute timeout to handle large files

### `internal/commands/commands.go`
- Added `StorachaGet(args []string)` command function
- Flags: `-cid` (required), `-file` (filename inside directory CID), `-out` (local output path, defaults to `-file` value)
- Follows same pattern as existing `S3Get` and `StorachaPut` commands

### `main.go`
- Added `storacha-get` case to command dispatcher
- Updated usage string to include `storacha-get`

### `README.md`
- Added download usage with flags explained

---

## Usage
```bash
# upload a file
./bin/rclone storacha-put -file ./photo.jpg
# prints: CID: bafybeihjnb...

# download it back
./bin/rclone storacha-get \
  -cid bafybeihjnbauyqkqq4xibszzm3jpjf4vhlgb2yddabqodnrmcbvdnihyau \
  -file photo.jpg \
  -out ./downloaded-photo.jpg

# verify
diff photo.jpg downloaded-photo.jpg
```

---


## Notes
- `storacha.link` and `w3s.link` path-style URLs were tried first but both redirect to subdomain-style URLs which caused DNS resolution failures on some systems — subdomain-style is used directly to avoid this
- `-file` flag is required when the CID is a directory (which is the default behavior of `storacha up`)
- Raw file CIDs (e.g. `bafkrei...`) work without `-file`