### PR TITLE
feat: bidirectional cp command (Storacha ↔ S3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Copies a file from Storacha (via IPFS gateway) into your configured S3 bucket.
   -file dog.txt \
   -s3-key backups/dog.txt
 
+# Copy a raw file CID (no -file needed — e.g. when uploaded via stdin/s3-key)
+./bin/rclone cp \
+  -cid bafkreiaipjxl4fc54n3cgm63xl4ka3b4fkz2a26kehydnq3ljabtk6jbne \
+  -s3-key yo.webp
+
 # -s3-key is optional — defaults to the value of -file
 ./bin/rclone cp \
   -cid bafybeihjnbauyqkqq4xibszzm3jpjf4vhlgb2yddabqodnrmcbvdnihyau \
@@ -68,7 +73,9 @@ Copies a file from Storacha (via IPFS gateway) into your configured S3 bucket.
 ```
 
 **Notes:**
-- `-cid` is the CID printed by `storacha-put` (required)
-- `-file` is the original filename inside the uploaded directory (required for directory CIDs)
+- `-cid` is the CID printed by `storacha-put` or `cp` (required)
+- `-file` is the original filename inside the uploaded directory (only needed for directory CIDs)
 - `-s3-key` is the destination key in S3 (defaults to `-file` value if omitted)
+- Raw file CIDs (e.g. `bafkrei...`) from stdin/S3 uploads don't need `-file`
 - Content is buffered in memory before upload to satisfy S3's `Content-Length` requirement
+- Falls back to `storacha.link` gateway if `w3s.link` is unavailable

--- a/README.md
+++ b/README.md
@@ -39,3 +39,36 @@ Delete files or folders from S3
 - Use `-prefix` with `-recursive` for folders
 - The `-force` flag skips confirmation prompts
 - Prefix deletion uses batch operations (1000 objects per API call)
+
+## Copy between S3 and Storacha
+
+The `cp` command supports copying files in both directions between S3 and Storacha.
+
+### S3 → Storacha
+
+Copies an object from your configured S3 bucket directly to Storacha (streamed, no temp file).
+```bash
+./bin/rclone cp -s3-key "path/to/file.txt"
+```
+
+### Storacha → S3
+
+Copies a file from Storacha (via IPFS gateway) into your configured S3 bucket.
+```bash
+# Copy a file from a directory CID (most common — storacha wraps uploads in a dir)
+./bin/rclone cp \
+  -cid bafybeihjnbauyqkqq4xibszzm3jpjf4vhlgb2yddabqodnrmcbvdnihyau \
+  -file dog.txt \
+  -s3-key backups/dog.txt
+
+# -s3-key is optional — defaults to the value of -file
+./bin/rclone cp \
+  -cid bafybeihjnbauyqkqq4xibszzm3jpjf4vhlgb2yddabqodnrmcbvdnihyau \
+  -file dog.txt
+```
+
+**Notes:**
+- `-cid` is the CID printed by `storacha-put` (required)
+- `-file` is the original filename inside the uploaded directory (required for directory CIDs)
+- `-s3-key` is the destination key in S3 (defaults to `-file` value if omitted)
+- Content is buffered in memory before upload to satisfy S3's `Content-Length` requirement

--- a/internal/aws/s3.go
+++ b/internal/aws/s3.go
@@ -99,6 +99,31 @@ func DownloadObject(ctx context.Context, ac appconfig.AppConfig, key, dest strin
 	return nil
 }
 
+func UploadObject(ctx context.Context, ac appconfig.AppConfig, key string, body io.Reader, contentLength int64) error {
+	awscfg, err := ConfigFromLocal(ctx, ac)
+	if err != nil {
+		return fmt.Errorf("AWS config: %v", err)
+	}
+	client := s3.NewFromConfig(awscfg)
+
+	input := &s3.PutObjectInput{
+		Bucket: &ac.Bucket,
+		Key:    &key,
+		Body:   body,
+	}
+	if contentLength > 0 {
+		input.ContentLength = &contentLength
+	}
+
+	_, err = client.PutObject(ctx, input)
+	if err != nil {
+		return fmt.Errorf("PutObject: %v", err)
+	}
+
+	fmt.Printf("✓ Uploaded to s3://%s/%s\n", ac.Bucket, key)
+	return nil
+}
+
 func DeleteObject(ctx context.Context, ac appconfig.AppConfig, key string) error {
 	awscfg, err := ConfigFromLocal(ctx, ac)
 	if err != nil {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -261,16 +263,36 @@ func StorachaPut(args []string) {
 
 func Copy(args []string) {
 	fs := flag.NewFlagSet("cp", flag.ExitOnError)
-	s3Key := fs.String("s3-key", "", "S3 object key to copy (required)")
+	s3Key := fs.String("s3-key", "", "S3 object key (source for s3→storacha, dest for storacha→s3)")
+	cid := fs.String("cid", "", "Storacha CID (source for storacha→s3)")
+	file := fs.String("file", "", "filename inside the CID directory (for storacha→s3)")
 	if err := fs.Parse(args); err != nil {
 		log.Fatal(err)
 	}
 
+	// storacha → s3: needs -cid and -s3-key
+	if *cid != "" {
+		if *s3Key == "" {
+			if *file != "" {
+				*s3Key = *file
+			} else {
+				*s3Key = *cid
+			}
+		}
+		copyStorachaToS3(args, *cid, *file, *s3Key)
+		return
+	}
+
+	// s3 → storacha: needs -s3-key
 	if *s3Key == "" {
+		fmt.Println("Error: must specify either -s3-key (for s3→storacha) or -cid (for storacha→s3)")
 		fs.Usage()
 		os.Exit(2)
 	}
+	copyS3ToStoracha(*s3Key)
+}
 
+func copyS3ToStoracha(s3Key string) {
 	awsCfg, err := config.Load()
 	if err != nil {
 		log.Fatal(err)
@@ -288,9 +310,9 @@ func Copy(args []string) {
 
 	ctx := context.Background()
 
-	fmt.Printf("Copying S3://%s/%s to Storacha...\n", awsCfg.Bucket, *s3Key)
+	fmt.Printf("Copying S3://%s/%s to Storacha...\n", awsCfg.Bucket, s3Key)
 
-	cid, err := storachaClient.UploadFromS3(ctx, awsCfg, *s3Key)
+	cid, err := storachaClient.UploadFromS3(ctx, awsCfg, s3Key)
 	if err != nil {
 		log.Fatalf("copy failed: %v", err)
 	}
@@ -298,4 +320,47 @@ func Copy(args []string) {
 	fmt.Printf("Copy successful!\n")
 	fmt.Printf("CID: %s\n", cid)
 	fmt.Printf("View at: https://w3s.link/ipfs/%s\n", cid)
+}
+
+func copyStorachaToS3(args []string, cid, file, s3Key string) {
+	storachaCfg, err := config.LoadStoracha()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	awsCfg, err := config.Load()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	storachaClient, err := storacha.NewClient(storachaCfg)
+	if err != nil {
+		log.Fatalf("create storacha client: %v", err)
+	}
+	defer storachaClient.Close()
+
+	ctx := context.Background()
+
+	fmt.Printf("Copying Storacha CID %s → s3://%s/%s\n", cid, awsCfg.Bucket, s3Key)
+
+	reader, _, err := storachaClient.DownloadToReader(ctx, cid, file)
+	if err != nil {
+		log.Fatalf("fetch from storacha: %v", err)
+	}
+	defer reader.Close()
+
+	fmt.Println("Buffering content...")
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		log.Fatalf("read from storacha: %v", err)
+	}
+
+	contentLength := int64(len(data))
+	fmt.Printf("Content length: %d bytes\n", contentLength)
+
+	if err := aws.UploadObject(ctx, awsCfg, s3Key, bytes.NewReader(data), contentLength); err != nil {
+		log.Fatalf("upload to S3: %v", err)
+	}
+
+	fmt.Printf("✓ Copy complete: Storacha/%s → s3://%s/%s\n", cid, awsCfg.Bucket, s3Key)
 }

--- a/internal/storacha/storacha.go
+++ b/internal/storacha/storacha.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"net/http"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -194,6 +195,38 @@ func (c *Client) UploadFromS3(ctx context.Context, awsCfg config.AppConfig, s3Ke
 	}
 
 	return cid, nil
+}
+
+func (c *Client) DownloadToReader(ctx context.Context, cid string, fileName string) (io.ReadCloser, int64, error) {
+	var url string
+	if fileName != "" {
+		url = fmt.Sprintf("https://%s.ipfs.w3s.link/%s", cid, fileName)
+	} else {
+		url = fmt.Sprintf("https://%s.ipfs.w3s.link", cid)
+	}
+
+	fmt.Printf("Fetching from: %s\n", url)
+
+	httpClient := &http.Client{
+		Timeout: 10 * time.Minute,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("http get: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, 0, fmt.Errorf("gateway returned status: %s", resp.Status)
+	}
+
+	return resp.Body, resp.ContentLength, nil
 }
 
 func (c *Client) Close() error {

--- a/internal/storacha/storacha.go
+++ b/internal/storacha/storacha.go
@@ -223,7 +223,26 @@ func (c *Client) DownloadToReader(ctx context.Context, cid string, fileName stri
 
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		return nil, 0, fmt.Errorf("gateway returned status: %s", resp.Status)
+		// fallback: try storacha.link gateway
+		fallbackURL := fmt.Sprintf("https://storacha.link/ipfs/%s", cid)
+		if fileName != "" {
+			fallbackURL = fmt.Sprintf("https://storacha.link/ipfs/%s/%s", cid, fileName)
+		}
+		fmt.Printf("w3s.link failed (%s), trying fallback: %s\n", resp.Status, fallbackURL)
+
+		req2, err := http.NewRequestWithContext(ctx, http.MethodGet, fallbackURL, nil)
+		if err != nil {
+			return nil, 0, fmt.Errorf("create fallback request: %w", err)
+		}
+		resp2, err := httpClient.Do(req2)
+		if err != nil {
+			return nil, 0, fmt.Errorf("fallback http get: %w", err)
+		}
+		if resp2.StatusCode != http.StatusOK {
+			resp2.Body.Close()
+			return nil, 0, fmt.Errorf("both gateways failed, last status: %s", resp2.Status)
+		}
+		return resp2.Body, resp2.ContentLength, nil
 	}
 
 	return resp.Body, resp.ContentLength, nil

--- a/internal/storacha/storacha.go
+++ b/internal/storacha/storacha.go
@@ -564,8 +564,7 @@ func getPackageDir() string {
 
 // Extract CID from output
 func extractCID(output string) string {
-	// Match CIDv1 (bafy...) or CIDv0 (Qm...)
-	re := regexp.MustCompile(`\b(bafy[a-zA-Z0-9]{50,}|Qm[a-zA-Z0-9]{44,})\b`)
+	re := regexp.MustCompile(`\b(bafy[a-zA-Z0-9]{50,}|bafk[a-zA-Z0-9]{50,}|Qm[a-zA-Z0-9]{44,})\b`)
 	for _, line := range strings.Split(output, "\n") {
 		if m := re.FindString(line); m != "" {
 			return m

--- a/main.go
+++ b/main.go
@@ -17,7 +17,9 @@ func main() {
 
   storacha-rclone storacha-login            # save Storacha credentials
   storacha-rclone storacha-put -file f      # upload file to Storacha
-  storacha-rclone cp -s3-key k              # copy S3 object to Storacha`)
+  storacha-rclone cp -s3-key k              # copy S3 object to Storacha
+  storacha-rclone cp -cid <cid> [-file f] [-s3-key k]      # copy Storacha to S3
+`)
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
## Summary

Extends the existing `cp` command to support copying files from **Storacha → S3**, 
complementing the already-supported **S3 → Storacha** direction. Also fixes CID extraction 
for `bafkrei...` type CIDs and adds gateway fallback for reliability.

## Changes

### `internal/commands/commands.go`
- Refactored `Copy` into direction-aware dispatcher — detects `storacha→s3` when `-cid` is 
  passed, falls back to existing `s3→storacha` when only `-s3-key` is passed
- Extracted `copyS3ToStoracha` (existing logic, no behaviour change)
- Added `copyStorachaToS3` — fetches from Storacha IPFS gateway, buffers content, uploads 
  to S3 with correct `Content-Length`

### `internal/storacha/storacha.go`
- Added `DownloadToReader` — returns an `io.ReadCloser` and content length from the 
  Storacha IPFS gateway (`w3s.link`), reusing gateway logic from `DownloadFile`
- Added `storacha.link` fallback in `DownloadToReader` if `w3s.link` returns non-200
- Fixed `extractCID` regex to also match `bafkrei...` CIDs (produced when uploading via 
  stdin e.g. `cp -s3-key`)

### `internal/aws/s3.go`
- Added `UploadObject` — wraps `PutObject` with an `io.Reader` + explicit `ContentLength`, 
  used by the storacha→s3 copy path

### `main.go`
- Updated usage string to document both `cp` directions

### `README.md`
- Added `cp` section documenting both S3→Storacha and Storacha→S3 directions
- Added raw file CID example (no `-file` flag needed for `bafkrei...` CIDs)
- Added fallback gateway note

## Usage
```bash
# s3 → storacha (unchanged)
./bin/rclone cp -s3-key path/to/file.txt

# storacha → s3 (directory CID — storacha wraps uploads in a dir)
./bin/rclone cp \
  -cid bafybeihjnbauyqkqq4xibszzm3jpjf4vhlgb2yddabqodnrmcbvdnihyau \
  -file dog.txt \
  -s3-key backups/dog.txt

# storacha → s3 (raw file CID — from stdin/s3-key uploads, no -file needed)
./bin/rclone cp \
  -cid bafkreiaipjxl4fc54n3cgm63xl4ka3b4fkz2a26kehydnq3ljabtk6jbne \
  -s3-key yo.webp

# storacha → s3 (-s3-key defaults to -file if omitted)
./bin/rclone cp \
  -cid bafybei... \
  -file dog.txt
```

## Bug Fixes

- `cp -s3-key` now correctly extracts and prints `bafkrei...` CIDs instead of failing with 
  `could not extract CID from output`
- `DownloadToReader` falls back to `storacha.link` gateway if `w3s.link` is unavailable

## Notes

- Storacha gateway (`w3s.link`) does not always return `Content-Length`, so content is 
  buffered in memory before upload to satisfy S3's required `Content-Length` header
- Future improvement: use S3 multipart upload to stream large files without full buffering

## Testing

- [x] `cp -s3-key` works for s3→storacha and now correctly prints `bafkrei...` CID
- [x] `cp -cid -file -s3-key` successfully copies directory CID from Storacha to S3
- [x] `cp -cid -s3-key` successfully copies raw file CID from Storacha to S3
- [x] `cp -cid -file` (no `-s3-key`) defaults destination key to filename
- [x] Gateway fallback works when `w3s.link` is unavailable
- [x] README updated with all examples and notes